### PR TITLE
Make sync resumable across Service Worker restarts

### DIFF
--- a/packages/background/src/etl.ts
+++ b/packages/background/src/etl.ts
@@ -1,10 +1,25 @@
 import type { SlackEmoji } from "shared";
 import { makeTeam, sleep } from "shared";
 
-export const etl = async (teamName: string) => {
-  const startedAt = new Date();
-  console.log("start etl:", teamName, startedAt);
+export interface UserEmoji {
+  name: string;
+  aliases: string[];
+  url: string;
+}
 
+export interface EtlBatchState {
+  teamName: string;
+  userEmojis: UserEmoji[];
+  processedIndex: number;
+  noPermissions: string[];
+  taken: string[];
+  startedAt: string;
+}
+
+export const prepareBatch = async (
+  teamName: string,
+): Promise<EtlBatchState> => {
+  console.log("prepareBatch:", teamName);
   const team = await makeTeam(teamName);
 
   const users = (await team.getUsers()).filter(
@@ -61,13 +76,31 @@ export const etl = async (teamName: string) => {
     };
   });
 
-  const noPermissions = new Set<string>();
-  const taken = new Set<string>();
-  for (const { name, aliases, url } of userEmojis) {
+  return {
+    teamName,
+    userEmojis,
+    processedIndex: 0,
+    noPermissions: [],
+    taken: [],
+    startedAt: new Date().toISOString(),
+  };
+};
+
+export const processFromIndex = async (
+  batch: EtlBatchState,
+): Promise<EtlBatchState> => {
+  const team = await makeTeam(batch.teamName);
+  const noPermissions = new Set<string>(batch.noPermissions);
+  const taken = new Set<string>(batch.taken);
+
+  for (let i = batch.processedIndex; i < batch.userEmojis.length; i++) {
+    const userEmoji = batch.userEmojis[i];
+    if (!userEmoji) continue;
+    const { name, aliases, url } = userEmoji;
+
     switch (await team.removeEmoji(name)) {
-          case undefined:
-            // ok
-            break;
+      case undefined:
+        break;
       case "no_permission":
         noPermissions.add(name);
         break;
@@ -76,9 +109,8 @@ export const etl = async (teamName: string) => {
         break;
     }
     switch (await team.addEmoji(name, url)) {
-          case undefined:
-            // ok
-            break;
+      case undefined:
+        break;
       case "fail_to_fetch_image":
         console.log("failed to add emoji:", name, url);
         break;
@@ -91,7 +123,6 @@ export const etl = async (teamName: string) => {
       for (;;) {
         switch (await team.removeEmoji(alias)) {
           case undefined:
-            // ok
             break;
           case "no_permission":
             noPermissions.add(alias);
@@ -102,9 +133,8 @@ export const etl = async (teamName: string) => {
         }
         switch (await team.aliasEmoji(alias, name)) {
           case undefined:
-            // ok
             break;
-          case "error_name_taken_i18n": // maybe built-in emoji name
+          case "error_name_taken_i18n":
             alias += "_";
             continue;
           case "error_name_taken":
@@ -120,19 +150,28 @@ export const etl = async (teamName: string) => {
       }
     }
 
+    // 進捗保存: killされてもここまでの処理は記録される
+    batch = {
+      ...batch,
+      processedIndex: i + 1,
+      noPermissions: Array.from(noPermissions),
+      taken: Array.from(taken),
+    };
+    await chrome.storage.local.set({ etlBatch: batch });
+
     await sleep(100);
   }
 
-  console.log("no permission:", Array.from(noPermissions));
-  console.log("taken:", Array.from(taken));
+  return batch;
+};
 
-  const toBeRemoved = new Set<string>();
-  for (const n of noPermissions) {
-    toBeRemoved.add(n);
-  }
-  for (const n of taken) {
-    toBeRemoved.add(n);
-  }
+export const finalizeBatch = async (batch: EtlBatchState): Promise<void> => {
+  const team = await makeTeam(batch.teamName);
+
+  console.log("no permission:", batch.noPermissions);
+  console.log("taken:", batch.taken);
+
+  const toBeRemoved = new Set<string>([...batch.noPermissions, ...batch.taken]);
 
   const emojis = await team.getEmojis();
   const nameToEmoji = new Map(emojis.map((emoji) => [emoji.name, emoji]));
@@ -159,13 +198,13 @@ export const etl = async (teamName: string) => {
   }
 
   const finishedAt = new Date();
+  const startedAt = new Date(batch.startedAt);
   console.log(
     "finish etl:",
-    teamName,
+    batch.teamName,
     Math.ceil((finishedAt.getTime() - startedAt.getTime()) / (1000 * 60)),
     "min",
   );
-  return;
 };
 
 const rTemporary = /(?:[(（].*[)）]|\d+\\\d+)/g;
@@ -179,7 +218,7 @@ const parseNames = (raw: string) =>
     .filter((name) => !rNumeric.test(name));
 
 const rInvalid = /[.\s]+/g;
-const rAlphabetical= /^[0-9a-zA-Z_-]+$/;
+const rAlphabetical = /^[0-9a-zA-Z_-]+$/;
 
 /**
  * Normalize a raw string to create valid emoji names.
@@ -189,16 +228,18 @@ const rAlphabetical= /^[0-9a-zA-Z_-]+$/;
  */
 const normalize = (raw: string) => {
   const trimmed = raw.trim();
-  const chunks = trimmed.split(rInvalid).filter(chunk => chunk.length > 0);
-  
+  const chunks = trimmed.split(rInvalid).filter((chunk) => chunk.length > 0);
+
   // Check if at least one chunk is alphabetical
-  const hasAlphabeticalChunk = chunks.some(chunk => rAlphabetical.test(chunk));
-  
+  const hasAlphabeticalChunk = chunks.some((chunk) =>
+    rAlphabetical.test(chunk),
+  );
+
   if (hasAlphabeticalChunk) {
     // Join chunks with underscore if we have alphabetical chunks
     return chunks.join("_").toLowerCase();
   }
-  
+
   // Otherwise join without separator
   return chunks.join("").toLowerCase();
 };

--- a/packages/background/src/main.ts
+++ b/packages/background/src/main.ts
@@ -1,10 +1,20 @@
 import { makeStorage } from "shared";
-import { etl } from "./etl";
+import {
+  type EtlBatchState,
+  finalizeBatch,
+  prepareBatch,
+  processFromIndex,
+} from "./etl";
 
 const storage = makeStorage();
 
+const ALARM_ETL = "etl";
+const ALARM_ETL_CONTINUE = "etl-continue";
+const PERIOD_MINUTES = 180;
+
 let etlRunning = false;
-const execEtl = async (teamName: string) => {
+
+const runEtl = async (teamName: string) => {
   if (!teamName) {
     return;
   }
@@ -14,7 +24,44 @@ const execEtl = async (teamName: string) => {
   }
   etlRunning = true;
   try {
-    await etl(teamName);
+    // バッチ状態確認
+    const { etlBatch } = (await chrome.storage.local.get("etlBatch")) as {
+      etlBatch?: EtlBatchState;
+    };
+
+    let batch: EtlBatchState;
+    if (
+      etlBatch &&
+      etlBatch.teamName === teamName &&
+      etlBatch.processedIndex < etlBatch.userEmojis.length
+    ) {
+      // 前回の続きから再開
+      console.log(
+        `resuming etl: ${etlBatch.processedIndex}/${etlBatch.userEmojis.length}`,
+      );
+      batch = etlBatch;
+    } else {
+      // 新規バッチ開始
+      batch = await prepareBatch(teamName);
+      await chrome.storage.local.set({ etlBatch: batch });
+    }
+
+    batch = await processFromIndex(batch);
+
+    if (batch.processedIndex >= batch.userEmojis.length) {
+      // 全件完了
+      await finalizeBatch(batch);
+      await chrome.storage.local.remove("etlBatch");
+      await chrome.storage.local.set({
+        lastEtlCompleted: new Date().toISOString(),
+      });
+      console.log("etl batch complete");
+    } else {
+      // killされて途中で終わった場合はここに来ない(killされるので)が、
+      // 念のため継続alarmをスケジュール
+      await chrome.alarms.create(ALARM_ETL_CONTINUE, { delayInMinutes: 1 });
+      console.log("etl batch interrupted, scheduled continue");
+    }
   } finally {
     etlRunning = false;
   }
@@ -25,28 +72,49 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
   console.log("onAlarm:", now, alarm);
   await chrome.storage.local.set({ lastAlarmFired: now });
   switch (alarm.name) {
-    case "etl":
+    case ALARM_ETL:
+    case ALARM_ETL_CONTINUE:
       await storage.init();
-      await execEtl(await storage.getTeam());
-      await chrome.storage.local.set({ lastEtlCompleted: now });
+      await runEtl(await storage.getTeam());
       break;
   }
 });
 
 chrome.runtime.onInstalled.addListener(async (reason) => {
   console.log("onInstalled:", reason);
-  await chrome.alarms.create("etl", { delayInMinutes: 1, periodInMinutes: 180 });
+  await chrome.alarms.create(ALARM_ETL, {
+    delayInMinutes: 1,
+    periodInMinutes: PERIOD_MINUTES,
+  });
   await storage.init();
-  await execEtl(await storage.getTeam());
+  await runEtl(await storage.getTeam());
 });
 
-// Service Worker復帰時にalarmが消えていたら再作成
-chrome.alarms.get("etl").then(async (alarm) => {
+// Service Worker復帰時にalarmが消えていたら再作成、バッチ途中なら継続alarmも作成
+chrome.alarms.get(ALARM_ETL).then(async (alarm) => {
   console.log("existing alarm:", alarm);
   if (!alarm) {
     console.log("alarm not found, recreating");
-    await chrome.alarms.create("etl", { delayInMinutes: 1, periodInMinutes: 180 });
+    await chrome.alarms.create(ALARM_ETL, {
+      delayInMinutes: 1,
+      periodInMinutes: PERIOD_MINUTES,
+    });
   }
+
+  // バッチ途中なら継続alarm作成
+  const { etlBatch } = (await chrome.storage.local.get("etlBatch")) as {
+    etlBatch?: EtlBatchState;
+  };
+  if (etlBatch && etlBatch.processedIndex < etlBatch.userEmojis.length) {
+    const existing = await chrome.alarms.get(ALARM_ETL_CONTINUE);
+    if (!existing) {
+      console.log(
+        `batch in progress (${etlBatch.processedIndex}/${etlBatch.userEmojis.length}), scheduling continue`,
+      );
+      await chrome.alarms.create(ALARM_ETL_CONTINUE, { delayInMinutes: 1 });
+    }
+  }
+
   const all = await chrome.alarms.getAll();
   console.log("all alarms:", all);
 });
@@ -54,10 +122,15 @@ chrome.alarms.get("etl").then(async (alarm) => {
 storage.onChangeTeam((team: string) => {
   (async () => {
     console.log("onChangeTeam:", team);
-    await execEtl(team);
+    // チーム変更時は進行中バッチをクリア
+    await chrome.storage.local.remove("etlBatch");
+    await runEtl(team);
   })().catch(console.error);
 });
 
-storage.init().then(() => {
-  console.log("background");
-}).catch(console.error);
+storage
+  .init()
+  .then(() => {
+    console.log("background");
+  })
+  .catch(console.error);


### PR DESCRIPTION
## Summary
- Split `etl()` into `prepareBatch` / `processFromIndex` / `finalizeBatch`
- Persist batch state to `chrome.storage.local` after each emoji so ETL can resume from the last processed index when the Service Worker is killed
- Add `etl-continue` alarm and recovery logic on Service Worker startup; clear batch state on team change

## Test plan
- [ ] Run ETL on a real team and verify it completes end-to-end
- [ ] Kill the Service Worker mid-run and confirm it resumes from the saved index
- [ ] Switch teams while a batch is in progress and confirm the old batch is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)