### PR TITLE
Rename ETL to sync

### DIFF
--- a/packages/background/src/main.ts
+++ b/packages/background/src/main.ts
@@ -1,49 +1,49 @@
 import { makeStorage } from "shared";
 import {
-  type EtlBatchState,
+  type SyncBatchState,
   finalizeBatch,
   prepareBatch,
   processFromIndex,
-} from "./etl";
+} from "./sync";
 
 const storage = makeStorage();
 
-const ALARM_ETL = "etl";
-const ALARM_ETL_CONTINUE = "etl-continue";
+const ALARM_SYNC = "sync";
+const ALARM_SYNC_CONTINUE = "sync-continue";
 const PERIOD_MINUTES = 180;
 
-let etlRunning = false;
+let syncRunning = false;
 
-const runEtl = async (teamName: string) => {
+const runSync = async (teamName: string) => {
   if (!teamName) {
     return;
   }
-  if (etlRunning) {
-    console.log("etl already running, skipping");
+  if (syncRunning) {
+    console.log("sync already running, skipping");
     return;
   }
-  etlRunning = true;
+  syncRunning = true;
   try {
     // バッチ状態確認
-    const { etlBatch } = (await chrome.storage.local.get("etlBatch")) as {
-      etlBatch?: EtlBatchState;
+    const { syncBatch } = (await chrome.storage.local.get("syncBatch")) as {
+      syncBatch?: SyncBatchState;
     };
 
-    let batch: EtlBatchState;
+    let batch: SyncBatchState;
     if (
-      etlBatch &&
-      etlBatch.teamName === teamName &&
-      etlBatch.processedIndex < etlBatch.userEmojis.length
+      syncBatch &&
+      syncBatch.teamName === teamName &&
+      syncBatch.processedIndex < syncBatch.userEmojis.length
     ) {
       // 前回の続きから再開
       console.log(
-        `resuming etl: ${etlBatch.processedIndex}/${etlBatch.userEmojis.length}`,
+        `resuming sync: ${syncBatch.processedIndex}/${syncBatch.userEmojis.length}`,
       );
-      batch = etlBatch;
+      batch = syncBatch;
     } else {
       // 新規バッチ開始
       batch = await prepareBatch(teamName);
-      await chrome.storage.local.set({ etlBatch: batch });
+      await chrome.storage.local.set({ syncBatch: batch });
     }
 
     batch = await processFromIndex(batch);
@@ -51,19 +51,19 @@ const runEtl = async (teamName: string) => {
     if (batch.processedIndex >= batch.userEmojis.length) {
       // 全件完了
       await finalizeBatch(batch);
-      await chrome.storage.local.remove("etlBatch");
+      await chrome.storage.local.remove("syncBatch");
       await chrome.storage.local.set({
-        lastEtlCompleted: new Date().toISOString(),
+        lastSyncCompleted: new Date().toISOString(),
       });
-      console.log("etl batch complete");
+      console.log("sync batch complete");
     } else {
       // killされて途中で終わった場合はここに来ない(killされるので)が、
       // 念のため継続alarmをスケジュール
-      await chrome.alarms.create(ALARM_ETL_CONTINUE, { delayInMinutes: 1 });
-      console.log("etl batch interrupted, scheduled continue");
+      await chrome.alarms.create(ALARM_SYNC_CONTINUE, { delayInMinutes: 1 });
+      console.log("sync batch interrupted, scheduled continue");
     }
   } finally {
-    etlRunning = false;
+    syncRunning = false;
   }
 };
 
@@ -72,46 +72,46 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
   console.log("onAlarm:", now, alarm);
   await chrome.storage.local.set({ lastAlarmFired: now });
   switch (alarm.name) {
-    case ALARM_ETL:
-    case ALARM_ETL_CONTINUE:
+    case ALARM_SYNC:
+    case ALARM_SYNC_CONTINUE:
       await storage.init();
-      await runEtl(await storage.getTeam());
+      await runSync(await storage.getTeam());
       break;
   }
 });
 
 chrome.runtime.onInstalled.addListener(async (reason) => {
   console.log("onInstalled:", reason);
-  await chrome.alarms.create(ALARM_ETL, {
+  await chrome.alarms.create(ALARM_SYNC, {
     delayInMinutes: 1,
     periodInMinutes: PERIOD_MINUTES,
   });
   await storage.init();
-  await runEtl(await storage.getTeam());
+  await runSync(await storage.getTeam());
 });
 
 // Service Worker復帰時にalarmが消えていたら再作成、バッチ途中なら継続alarmも作成
-chrome.alarms.get(ALARM_ETL).then(async (alarm) => {
+chrome.alarms.get(ALARM_SYNC).then(async (alarm) => {
   console.log("existing alarm:", alarm);
   if (!alarm) {
     console.log("alarm not found, recreating");
-    await chrome.alarms.create(ALARM_ETL, {
+    await chrome.alarms.create(ALARM_SYNC, {
       delayInMinutes: 1,
       periodInMinutes: PERIOD_MINUTES,
     });
   }
 
   // バッチ途中なら継続alarm作成
-  const { etlBatch } = (await chrome.storage.local.get("etlBatch")) as {
-    etlBatch?: EtlBatchState;
+  const { syncBatch } = (await chrome.storage.local.get("syncBatch")) as {
+    syncBatch?: SyncBatchState;
   };
-  if (etlBatch && etlBatch.processedIndex < etlBatch.userEmojis.length) {
-    const existing = await chrome.alarms.get(ALARM_ETL_CONTINUE);
+  if (syncBatch && syncBatch.processedIndex < syncBatch.userEmojis.length) {
+    const existing = await chrome.alarms.get(ALARM_SYNC_CONTINUE);
     if (!existing) {
       console.log(
-        `batch in progress (${etlBatch.processedIndex}/${etlBatch.userEmojis.length}), scheduling continue`,
+        `batch in progress (${syncBatch.processedIndex}/${syncBatch.userEmojis.length}), scheduling continue`,
       );
-      await chrome.alarms.create(ALARM_ETL_CONTINUE, { delayInMinutes: 1 });
+      await chrome.alarms.create(ALARM_SYNC_CONTINUE, { delayInMinutes: 1 });
     }
   }
 
@@ -123,8 +123,8 @@ storage.onChangeTeam((team: string) => {
   (async () => {
     console.log("onChangeTeam:", team);
     // チーム変更時は進行中バッチをクリア
-    await chrome.storage.local.remove("etlBatch");
-    await runEtl(team);
+    await chrome.storage.local.remove("syncBatch");
+    await runSync(team);
   })().catch(console.error);
 });
 

--- a/packages/background/src/sync.ts
+++ b/packages/background/src/sync.ts
@@ -7,7 +7,7 @@ export interface UserEmoji {
   url: string;
 }
 
-export interface EtlBatchState {
+export interface SyncBatchState {
   teamName: string;
   userEmojis: UserEmoji[];
   processedIndex: number;
@@ -18,7 +18,7 @@ export interface EtlBatchState {
 
 export const prepareBatch = async (
   teamName: string,
-): Promise<EtlBatchState> => {
+): Promise<SyncBatchState> => {
   console.log("prepareBatch:", teamName);
   const team = await makeTeam(teamName);
 
@@ -87,8 +87,8 @@ export const prepareBatch = async (
 };
 
 export const processFromIndex = async (
-  batch: EtlBatchState,
-): Promise<EtlBatchState> => {
+  batch: SyncBatchState,
+): Promise<SyncBatchState> => {
   const team = await makeTeam(batch.teamName);
   const noPermissions = new Set<string>(batch.noPermissions);
   const taken = new Set<string>(batch.taken);
@@ -157,7 +157,7 @@ export const processFromIndex = async (
       noPermissions: Array.from(noPermissions),
       taken: Array.from(taken),
     };
-    await chrome.storage.local.set({ etlBatch: batch });
+    await chrome.storage.local.set({ syncBatch: batch });
 
     await sleep(100);
   }
@@ -165,7 +165,7 @@ export const processFromIndex = async (
   return batch;
 };
 
-export const finalizeBatch = async (batch: EtlBatchState): Promise<void> => {
+export const finalizeBatch = async (batch: SyncBatchState): Promise<void> => {
   const team = await makeTeam(batch.teamName);
 
   console.log("no permission:", batch.noPermissions);
@@ -200,7 +200,7 @@ export const finalizeBatch = async (batch: EtlBatchState): Promise<void> => {
   const finishedAt = new Date();
   const startedAt = new Date(batch.startedAt);
   console.log(
-    "finish etl:",
+    "finish sync:",
     batch.teamName,
     Math.ceil((finishedAt.getTime() - startedAt.getTime()) / (1000 * 60)),
     "min",


### PR DESCRIPTION
## Summary
- avatarをemojiに登録する処理は ETL ではなく sync が適切なので名称を統一
- `etl.ts` → `sync.ts`、`EtlBatchState` → `SyncBatchState`、`runEtl`/`etlRunning` → `runSync`/`syncRunning`
- chrome.storage キー (`etlBatch`/`lastEtlCompleted`) と alarm 名 (`etl`/`etl-continue`) も sync 系に変更

## Note
storage キーと alarm 名を変更したため、既存ユーザーの進行中バッチ状態は失われ次回 alarm で新規バッチが開始される。旧 alarm は `onInstalled` で新名にて作り直される。

## Test plan
- [ ] 型チェック通過 (`pnpm -F background exec tsc --noEmit`)
- [ ] 拡張機能をリロードして sync alarm が作成されることを確認
- [ ] バッチが完了し `lastSyncCompleted` が記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)