### PR TITLE
Document sync cycle with mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ Features:
 - Automatically process once a day.
 - Add a custom emoji with a user name and register the display name of the user profile as aliases for that emoji. The display name is split with '/' or '|' and registered as multiple aliases.
 
+## How sync works
+
+The sync cycle is driven by `chrome.alarms` and resumable across Service Worker restarts. A periodic alarm fires every 3 hours and runs a batch over all users; progress is persisted per user, so a kill/restart picks up from the last processed index.
+
+```mermaid
+flowchart TD
+  Install([onInstalled / browser start]) --> CreateAlarm[Create ALARM_SYNC every 180min]
+  CreateAlarm --> Idle
+  Idle{SW idle/stopped} -->|ALARM_SYNC fires<br/>every 3h| Wake[SW wakes up]
+  Idle -->|ALARM_SYNC_CONTINUE fires<br/>1min after interrupt| Wake
+  Idle -->|popup / team change| Wake
+  Wake --> Check{syncBatch in<br/>chrome.storage.local?}
+  Check -->|yes, unfinished| Resume[Resume from processedIndex]
+  Check -->|no| Prepare[prepareBatch:<br/>fetch users + build emoji list]
+  Prepare --> Process
+  Resume --> Process[processFromIndex:<br/>loop users one by one]
+  Process --> SaveProgress[Save processedIndex<br/>to storage per user]
+  SaveProgress --> MoreUsers{more users?}
+  MoreUsers -->|yes| Process
+  MoreUsers -->|no| Finalize[finalizeBatch +<br/>clear syncBatch]
+  Finalize --> Idle
+
+  Process -.->|SW killed<br/>5min limit / browser close| Killed([SW terminated])
+  Killed -.->|next alarm or popup| Wake
+```
+
+Slack rate limits (HTTP 429 with `Retry-After`, or HTTP 5xx) are handled inside `fetchSlackWithRetry` with header-driven sleep and exponential backoff, so the loop itself does not need to know about retries.
+
 ## Installation
 
 ### Chrome Web Store (recommended)

--- a/packages/misc/src/README.md
+++ b/packages/misc/src/README.md
@@ -18,6 +18,34 @@ Features:
 - Automatically process once a day.
 - Add a custom emoji with a user name and register the display name of the user profile as aliases for that emoji. The display name is split with '/' or '|' and registered as multiple aliases.
 
+## How sync works
+
+The sync cycle is driven by `chrome.alarms` and resumable across Service Worker restarts. A periodic alarm fires every 3 hours and runs a batch over all users; progress is persisted per user, so a kill/restart picks up from the last processed index.
+
+```mermaid
+flowchart TD
+  Install([onInstalled / browser start]) --> CreateAlarm[Create ALARM_SYNC every 180min]
+  CreateAlarm --> Idle
+  Idle{SW idle/stopped} -->|ALARM_SYNC fires<br/>every 3h| Wake[SW wakes up]
+  Idle -->|ALARM_SYNC_CONTINUE fires<br/>1min after interrupt| Wake
+  Idle -->|popup / team change| Wake
+  Wake --> Check{syncBatch in<br/>chrome.storage.local?}
+  Check -->|yes, unfinished| Resume[Resume from processedIndex]
+  Check -->|no| Prepare[prepareBatch:<br/>fetch users + build emoji list]
+  Prepare --> Process
+  Resume --> Process[processFromIndex:<br/>loop users one by one]
+  Process --> SaveProgress[Save processedIndex<br/>to storage per user]
+  SaveProgress --> MoreUsers{more users?}
+  MoreUsers -->|yes| Process
+  MoreUsers -->|no| Finalize[finalizeBatch +<br/>clear syncBatch]
+  Finalize --> Idle
+
+  Process -.->|SW killed<br/>5min limit / browser close| Killed([SW terminated])
+  Killed -.->|next alarm or popup| Wake
+```
+
+Slack rate limits (HTTP 429 with `Retry-After`, or HTTP 5xx) are handled inside `fetchSlackWithRetry` with header-driven sleep and exponential backoff, so the loop itself does not need to know about retries.
+
 ## Installation
 
 ### Chrome Web Store (recommended)


### PR DESCRIPTION
## Summary
- README に Service Worker / sync バッチのライフサイクルを mermaid フローチャートで図解。alarm 起動経路・バッチ途中再開・SW kill 時の復帰経路を可視化。
- テンプレート (`packages/misc/src/README.md`) と生成済み `README.md` 両方を更新。

## Test plan
- [x] `pnpm run --filter misc build:gen:readme` 成功
- [ ] GitHub 上で README の mermaid 図が描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)