### PR TITLE
Schedule next sync 1h after completion (one-shot alarm)

### DIFF
--- a/packages/background/src/main.ts
+++ b/packages/background/src/main.ts
@@ -10,9 +10,17 @@ const storage = makeStorage();
 
 const ALARM_SYNC = "sync";
 const ALARM_SYNC_CONTINUE = "sync-continue";
-const PERIOD_MINUTES = 180;
+const POST_SYNC_DELAY_MINUTES = 60;
+const FALLBACK_DELAY_MINUTES = 1;
 
 let syncRunning = false;
+
+const scheduleNextSync = async () => {
+  await chrome.alarms.create(ALARM_SYNC, {
+    delayInMinutes: POST_SYNC_DELAY_MINUTES,
+  });
+  console.log(`next sync scheduled in ${POST_SYNC_DELAY_MINUTES}min`);
+};
 
 const runSync = async (teamName: string) => {
   if (!teamName) {
@@ -56,6 +64,8 @@ const runSync = async (teamName: string) => {
         lastSyncCompleted: new Date().toISOString(),
       });
       console.log("sync batch complete");
+      // 完了から POST_SYNC_DELAY_MINUTES 後に次回をスケジュール
+      await scheduleNextSync();
     } else {
       // killされて途中で終わった場合はここに来ない(killされるので)が、
       // 念のため継続alarmをスケジュール
@@ -83,8 +93,7 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 chrome.runtime.onInstalled.addListener(async (reason) => {
   console.log("onInstalled:", reason);
   await chrome.alarms.create(ALARM_SYNC, {
-    delayInMinutes: 1,
-    periodInMinutes: PERIOD_MINUTES,
+    delayInMinutes: FALLBACK_DELAY_MINUTES,
   });
   await storage.init();
   await runSync(await storage.getTeam());
@@ -93,19 +102,20 @@ chrome.runtime.onInstalled.addListener(async (reason) => {
 // Service Worker復帰時にalarmが消えていたら再作成、バッチ途中なら継続alarmも作成
 chrome.alarms.get(ALARM_SYNC).then(async (alarm) => {
   console.log("existing alarm:", alarm);
-  if (!alarm) {
-    console.log("alarm not found, recreating");
-    await chrome.alarms.create(ALARM_SYNC, {
-      delayInMinutes: 1,
-      periodInMinutes: PERIOD_MINUTES,
-    });
-  }
 
-  // バッチ途中なら継続alarm作成
   const { syncBatch } = (await chrome.storage.local.get("syncBatch")) as {
     syncBatch?: SyncBatchState;
   };
-  if (syncBatch && syncBatch.processedIndex < syncBatch.userEmojis.length) {
+  const batchInProgress =
+    !!syncBatch && syncBatch.processedIndex < syncBatch.userEmojis.length;
+
+  if (!alarm && !batchInProgress) {
+    // セーフティネット: alarm も batch も無ければ次回を予約
+    console.log("alarm not found, recreating");
+    await scheduleNextSync();
+  }
+
+  if (batchInProgress) {
     const existing = await chrome.alarms.get(ALARM_SYNC_CONTINUE);
     if (!existing) {
       console.log(


### PR DESCRIPTION
## Summary
- 3 時間固定の periodic alarm を廃止し、`finalizeBatch` 完了直後に `delayInMinutes: 60` でワンショット登録に変更。
- 完了→次回開始の間隔が「前回完了 + 1h」で予測可能になり、batch 重複（前回が走っている間に次が起動）が原理的に発生しなくなる。
- 中断復帰の安全網は維持: `syncBatch` 永続化 + `ALARM_SYNC_CONTINUE`（1 分後再開）+ SW 復帰時のセーフティネットで「alarm 無し & batch 無し」なら `ALARM_SYNC` を再登録。

## How alarm is (re)created
- `onInstalled`: 初回 `delayInMinutes: 1`
- `runSync` 完了時: `delayInMinutes: 60`
- SW 復帰時セーフティネット: alarm も batch も無ければ `delayInMinutes: 60`

## Test plan
- [x] `pnpm -r run check:tsc`
- [x] `pnpm run build`
- [ ] Chrome に `out/` を読み込み、SW コンソールで `next sync scheduled in 60min` ログを確認、`chrome.alarms.getAll()` で残り時間を検証
- [ ] `chrome.alarms.clear("sync")` 後に SW を一度停止 → 起こすとセーフティネットで再登録される
- [ ] 大きい team で SW kill を誘発し、`ALARM_SYNC_CONTINUE` から続きが再開されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)