### PR TITLE
Allow fetching emoji images from secure.gravatar.com

### DIFF
--- a/packages/misc/src/manifest.json
+++ b/packages/misc/src/manifest.json
@@ -4,7 +4,11 @@
   "description": "<%- description %>",
   "version": "<%- version %>",
   "permissions": ["alarms", "storage"],
-  "host_permissions": ["https://*.slack.com/*", "https://*.slack-edge.com/*"],
+  "host_permissions": [
+    "https://*.slack.com/*",
+    "https://*.slack-edge.com/*",
+    "https://secure.gravatar.com/*"
+  ],
   "icons": {
     "128": "icon-128.png"
   },

--- a/packages/misc/src/manifest.json
+++ b/packages/misc/src/manifest.json
@@ -7,7 +7,7 @@
   "host_permissions": [
     "https://*.slack.com/*",
     "https://*.slack-edge.com/*",
-    "https://secure.gravatar.com/*"
+    "https://secure.gravatar.com/avatar/*"
   ],
   "icons": {
     "128": "icon-128.png"


### PR DESCRIPTION
## Summary
- Slack avatars often redirect to Gravatar, and fetching those images from the extension origin (`chrome-extension://...`) failed with CORS errors because `secure.gravatar.com` does not return `Access-Control-Allow-Origin`.
- Add `https://secure.gravatar.com/*` to `host_permissions` so the extension can fetch these images directly.

## Test plan
- [ ] Reload the extension and run a sync that includes a user whose avatar resolves to Gravatar; confirm no `add: fetch image error` is logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)