### PR TITLE
Adopt kwcp-style draft-release flow

### DIFF
--- a/.claude/skills/publish-extension/SKILL.md
+++ b/.claude/skills/publish-extension/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: publish-extension
+description: GitHub Release を作成して Chrome Web Store にパブリッシュする
+---
+
+## Uemoji Publish
+
+uemoji の GitHub Release を作成し、CI 経由で Chrome Web Store
+にパブリッシュするスキル。
+
+### 手順
+
+1. `gh release list --limit 5` で最新リリースバージョンを確認する
+2. `git log <最新タグ>..HEAD --oneline` で前回リリース以降の変更を確認する
+3. 変更内容に基づいて次のバージョンを決定する
+   - `feat` が含まれる場合: マイナーバージョンを上げる
+   - `fix` のみの場合: パッチバージョンを上げる
+   - 破壊的変更がある場合: メジャーバージョンを上げる
+   - 判断に迷う場合はユーザーに確認する
+4. ルートの `package.json` の `version` を新バージョンに更新する PR を作成しマージする
+   （manifest.json は `package.json` から ejs で生成されるため、ここを上げないと
+   Chrome Web Store 側のバージョン重複でリジェクトされる）
+5. `gh release create v<version> --generate-notes --draft` で draft リリースを作成する
+   （CI が `created` イベントでトリガーされ、ビルド・アップロード後に自動で publish される）
+6. `gh run list --limit 1` で CI の実行状況を監視し、成功を確認する
+7. リリースが publish されたことを `gh release view v<version>` で確認する
+
+### ルール
+
+- タグは必ず `v<version>` 形式にする（例: `v0.0.9`, `v1.2.3`）
+- Release は必ず `--draft` で作成する（CI が draft にアセットをアップロードした後、
+  自動で publish する）
+- `package.json` の version を上げずにタグだけ作ると Chrome Web Store のアップロードが
+  失敗する。必ず PR でバージョンを上げてから release を作成する
+- CI が失敗した場合はエラー内容をユーザーに報告する

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,15 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  release:
+    types: [created]
 
 jobs:
   build:
+    name: Build
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,15 +27,57 @@ jobs:
         run: pnpm run build
       - name: Zip
         run: zip -r uemoji.zip out
-      - name: Upload to GitHub releases
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          files: uemoji.zip
-      - name: Upload to chrome web store
-        run: |
-          npx chrome-webstore-upload-cli@2 upload --source uemoji.zip --auto-publish
+          name: uemoji-zip
+          path: uemoji.zip
+
+  github-release:
+    name: Upload to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: uemoji-zip
+      - name: Upload to GitHub release
+        run: gh release upload "$TAG_NAME" uemoji.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+
+  webstore-upload:
+    name: Upload to Chrome Web Store
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: uemoji-zip
+      - name: Upload to Chrome Web Store
+        run: npx chrome-webstore-upload-cli@2 upload --source uemoji.zip --auto-publish
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
+
+  publish:
+    name: Publish Release
+    needs: [github-release, webstore-upload]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish draft release
+        run: gh release edit "$TAG_NAME" --draft=false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary
- Release ワークフローのトリガーを tag push (`on: push: tags: v*.*.*`) から GitHub Release 作成 (`on: release: types: [created]`) に変更
- ビルド → GitHub Release への asset アップロード → Chrome Web Store への auto-publish → 全部成功したら `gh release edit --draft=false` で draft を公開、というアトミックなフローに
- 失敗時はドラフトのまま残るので、中途半端なリリースが公開される事故を防げる
- `.claude/skills/publish-extension/SKILL.md` を追加。kwcp の scepter publish スキルを uemoji 用（拡張機能 1つ、タグプレフィックスなし）に簡略化したもの

## リリース手順（新フロー）
1. `package.json` の version を bump する PR を作ってマージ
2. `gh release create v<version> --generate-notes --draft` で draft 作成
3. CI がビルド + GitHub Release アップロード + Chrome Web Store アップロードを実行
4. 全部成功すると CI が自動で `--draft=false` にして公開

## Test plan
- [ ] mergeしたあとに `gh release create v0.0.9 --generate-notes --draft` で動作確認
- [ ] CI の各ジョブ（build / github-release / webstore-upload / publish）が順に成功
- [ ] 失敗時はドラフトのまま残ることを確認（webstore のシークレット未設定などで意図的に失敗させる必要があるので無理にやらなくてもよい）

🤖 Generated with [Claude Code](https://claude.com/claude-code)