### PR TITLE
Trigger release workflow on published

### DIFF
--- a/.claude/skills/publish-extension/SKILL.md
+++ b/.claude/skills/publish-extension/SKILL.md
@@ -17,16 +17,16 @@ uemoji の GitHub Release を作成し、CI 経由で Chrome Web Store
    - `fix` のみの場合: パッチバージョンを上げる
    - 破壊的変更がある場合: メジャーバージョンを上げる
    - 判断に迷う場合はユーザーに確認する
-4. `gh release create v<version> --generate-notes --draft` で draft リリースを作成する
-   （CI が `created` イベントでトリガーされ、tag 名から `v` を剥がしたものを `VERSION`
-   env として build に渡し、manifest.json に注入する）
-5. `gh run list --limit 1` で CI の実行状況を監視し、成功を確認する
-6. リリースが publish されたことを `gh release view v<version>` で確認する
+4. `gh release create v<version> --generate-notes` でリリースを作成する
+   （CI が `published` イベントでトリガーされ、tag 名から `v` を剥がしたものを
+   `VERSION` env として build に渡し、manifest.json に注入する）
+5. `gh run list --workflow=Release --limit 1` で CI の実行状況を監視し、成功を確認する
+6. リリースに zip が添付されたことを `gh release view v<version>` で確認する
 
 ### ルール
 
 - タグは必ず `v<version>` 形式にする（例: `v0.0.9`, `v1.2.3`）
-- Release は必ず `--draft` で作成する（CI が draft にアセットをアップロードした後、
-  自動で publish する）
 - バージョンは tag 名が単一の真実。`package.json` には `version` を持たない
-- CI が失敗した場合はエラー内容をユーザーに報告する
+- CI が失敗した場合は、`gh release delete v<version> --cleanup-tag` で公開済みリリースを
+  削除してからユーザーに報告する（publish 後にトリガーされる方式のため、失敗時は
+  zip 無しの公開リリースが残ることがある）

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:
@@ -70,16 +70,3 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
 
-  publish:
-    name: Publish Release
-    needs: [github-release, webstore-upload]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Publish draft release
-        run: gh release edit "$TAG_NAME" --draft=false
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TAG_NAME: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary
- Release workflow のトリガーを `release: types: [created]` から `release: types: [published]` に変更
- `created` は GitHub 公式ドキュメント上 draft では発火しない type で、実際 uemoji では draft 保存・publish 両方とも発火しなかった
- `published` は「release/pre-release/draft が publish された時に発火」と明示されている公式 type
- 連動して `publish` ジョブ（draft → publish に flip するためのもの）を削除。新しいトリガーでは release はすでに published 状態で workflow が走るので不要
- スキルの手順とルールを更新（`--draft` 不要、失敗時のクリーンアップ手順を追加）

## トレードオフ
- 失う: build 失敗時に draft のまま止まる atomicity
- 残るリスク: zip 無しで公開された v<version> が残る → スキルでは失敗時に `gh release delete --cleanup-tag` で削除する手順を明記

## Test plan
- [ ] merge 後に `gh release create v0.0.9 --generate-notes` でリリース作成
- [ ] Release workflow が発火し、build / github-release / webstore-upload が成功する
- [ ] release ページに `uemoji.zip` が添付される
- [ ] Chrome Web Store に v0.0.9 がアップロードされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)