### PR TITLE
Refresh avatar URLs on batch resume

### DIFF
--- a/packages/background/src/main.ts
+++ b/packages/background/src/main.ts
@@ -33,7 +33,7 @@ const runSync = async (teamName: string) => {
   }
   syncRunning = true;
   try {
-    // バッチ状態確認
+    // Check for an in-progress batch
     const { syncBatch } = (await chrome.storage.local.get("syncBatch")) as {
       syncBatch?: SyncBatchState;
     };
@@ -44,15 +44,16 @@ const runSync = async (teamName: string) => {
       syncBatch.teamName === teamName &&
       syncBatch.processedIndex < syncBatch.userEmojis.length
     ) {
-      // 前回の続きから再開。バッチ作成時のアバターURLは古い可能性が
-      // あるので、users.listを取り直してURLを更新してから処理する
+      // Resume from the previous run. Avatar URLs snapshotted at
+      // prepareBatch time may be stale, so re-fetch users.list and
+      // refresh them before processing
       console.log(
         `resuming sync: ${syncBatch.processedIndex}/${syncBatch.userEmojis.length}`,
       );
       batch = await refreshAvatarUrls(syncBatch);
       await chrome.storage.local.set({ syncBatch: batch });
     } else {
-      // 新規バッチ開始
+      // Start a new batch
       batch = await prepareBatch(teamName);
       await chrome.storage.local.set({ syncBatch: batch });
     }
@@ -60,18 +61,18 @@ const runSync = async (teamName: string) => {
     batch = await processFromIndex(batch);
 
     if (batch.processedIndex >= batch.userEmojis.length) {
-      // 全件完了
+      // All entries processed
       await finalizeBatch(batch);
       await chrome.storage.local.remove("syncBatch");
       await chrome.storage.local.set({
         lastSyncCompleted: new Date().toISOString(),
       });
       console.log("sync batch complete");
-      // 完了から POST_SYNC_DELAY_MINUTES 後に次回をスケジュール
+      // Schedule the next sync POST_SYNC_DELAY_MINUTES after completion
       await scheduleNextSync();
     } else {
-      // killされて途中で終わった場合はここに来ない(killされるので)が、
-      // 念のため継続alarmをスケジュール
+      // When the service worker is killed mid-batch we never reach
+      // here, but schedule a continue alarm just in case
       await chrome.alarms.create(ALARM_SYNC_CONTINUE, { delayInMinutes: 1 });
       console.log("sync batch interrupted, scheduled continue");
     }
@@ -102,7 +103,8 @@ chrome.runtime.onInstalled.addListener(async (reason) => {
   await runSync(await storage.getTeam());
 });
 
-// Service Worker復帰時にalarmが消えていたら再作成、バッチ途中なら継続alarmも作成
+// On service worker wake-up, recreate the alarm if it's gone, and
+// schedule a continue alarm if a batch is in progress
 chrome.alarms.get(ALARM_SYNC).then(async (alarm) => {
   console.log("existing alarm:", alarm);
 
@@ -113,7 +115,7 @@ chrome.alarms.get(ALARM_SYNC).then(async (alarm) => {
     !!syncBatch && syncBatch.processedIndex < syncBatch.userEmojis.length;
 
   if (!alarm && !batchInProgress) {
-    // セーフティネット: alarm も batch も無ければ次回を予約
+    // Safety net: schedule the next sync if neither an alarm nor a batch exists
     console.log("alarm not found, recreating");
     await scheduleNextSync();
   }
@@ -135,7 +137,7 @@ chrome.alarms.get(ALARM_SYNC).then(async (alarm) => {
 storage.onChangeTeam((team: string) => {
   (async () => {
     console.log("onChangeTeam:", team);
-    // チーム変更時は進行中バッチをクリア
+    // Clear the in-progress batch when the team changes
     await chrome.storage.local.remove("syncBatch");
     await runSync(team);
   })().catch(console.error);

--- a/packages/background/src/main.ts
+++ b/packages/background/src/main.ts
@@ -4,6 +4,7 @@ import {
   finalizeBatch,
   prepareBatch,
   processFromIndex,
+  refreshAvatarUrls,
 } from "./sync";
 
 const storage = makeStorage();
@@ -43,11 +44,13 @@ const runSync = async (teamName: string) => {
       syncBatch.teamName === teamName &&
       syncBatch.processedIndex < syncBatch.userEmojis.length
     ) {
-      // 前回の続きから再開
+      // 前回の続きから再開。バッチ作成時のアバターURLは古い可能性が
+      // あるので、users.listを取り直してURLを更新してから処理する
       console.log(
         `resuming sync: ${syncBatch.processedIndex}/${syncBatch.userEmojis.length}`,
       );
-      batch = syncBatch;
+      batch = await refreshAvatarUrls(syncBatch);
+      await chrome.storage.local.set({ syncBatch: batch });
     } else {
       // 新規バッチ開始
       batch = await prepareBatch(teamName);

--- a/packages/background/src/sync.ts
+++ b/packages/background/src/sync.ts
@@ -100,9 +100,10 @@ export const prepareBatch = async (
   };
 };
 
-// バッチ再開時にusers.listを取り直し、user_idで引き直してURLだけ差し替える。
-// 配列の順序・処理済みindexは変えないので、名前変更や入退社があってもズレない。
-// 取得できなかったユーザー(退社など)はバッチ作成時のURLをそのまま使う。
+// Re-fetch users.list on batch resume and swap in fresh avatar URLs
+// keyed by user ID. Array order and processedIndex are untouched, so
+// renames or departures during a batch never shift resume progress.
+// Users missing from the fresh list keep their original URL.
 export const refreshAvatarUrls = async (
   batch: SyncBatchState,
 ): Promise<SyncBatchState> => {
@@ -181,7 +182,7 @@ export const processFromIndex = async (
       }
     }
 
-    // 進捗保存: killされてもここまでの処理は記録される
+    // Persist progress so it survives a service worker kill
     batch = {
       ...batch,
       processedIndex: i + 1,

--- a/packages/background/src/sync.ts
+++ b/packages/background/src/sync.ts
@@ -1,11 +1,26 @@
-import type { SlackEmoji } from "shared";
+import type { SlackEmoji, SlackUser } from "shared";
 import { makeTeam, sleep } from "shared";
 
 export interface UserEmoji {
+  userId: string;
   name: string;
   aliases: string[];
   url: string;
 }
+
+// Users without a custom avatar get a Gravatar fallback URL in
+// image_*, and Gravatar doesn't return CORS headers, so fetching
+// from the extension fails. These users have an avatar_hash that
+// starts with "g" (custom-avatar users have a plain hex hash; only
+// Slack's default fallback uses the "g" + hex form). Substitute a
+// bundled placeholder image so the emoji name is still reserved.
+const avatarUrl = (user: SlackUser): string =>
+  user.profile.avatar_hash?.startsWith("g")
+    ? chrome.runtime.getURL("default-avatar.png")
+    : user.profile.image_72 ||
+      user.profile.image_48 ||
+      user.profile.image_32 ||
+      user.profile.image_24;
 
 export interface SyncBatchState {
   teamName: string;
@@ -67,23 +82,11 @@ export const prepareBatch = async (
       ),
     );
 
-    // Users without a custom avatar get a Gravatar fallback URL in
-    // image_*, and Gravatar doesn't return CORS headers, so fetching
-    // from the extension fails. These users have an avatar_hash that
-    // starts with "g" (custom-avatar users have a plain hex hash; only
-    // Slack's default fallback uses the "g" + hex form). Substitute a
-    // bundled placeholder image so the emoji name is still reserved.
-    const url = user.profile.avatar_hash?.startsWith("g")
-      ? chrome.runtime.getURL("default-avatar.png")
-      : user.profile.image_72 ||
-        user.profile.image_48 ||
-        user.profile.image_32 ||
-        user.profile.image_24;
-
     return {
+      userId: user.id,
       name,
       aliases,
-      url,
+      url: avatarUrl(user),
     };
   });
 
@@ -94,6 +97,23 @@ export const prepareBatch = async (
     noPermissions: [],
     taken: [],
     startedAt: new Date().toISOString(),
+  };
+};
+
+// バッチ再開時にusers.listを取り直し、user_idで引き直してURLだけ差し替える。
+// 配列の順序・処理済みindexは変えないので、名前変更や入退社があってもズレない。
+// 取得できなかったユーザー(退社など)はバッチ作成時のURLをそのまま使う。
+export const refreshAvatarUrls = async (
+  batch: SyncBatchState,
+): Promise<SyncBatchState> => {
+  const team = await makeTeam(batch.teamName);
+  const users = new Map((await team.getUsers()).map((user) => [user.id, user]));
+  return {
+    ...batch,
+    userEmojis: batch.userEmojis.map((userEmoji) => {
+      const user = users.get(userEmoji.userId);
+      return user ? { ...userEmoji, url: avatarUrl(user) } : userEmoji;
+    }),
   };
 };
 

--- a/packages/misc/scripts/gen-manifest.mjs
+++ b/packages/misc/scripts/gen-manifest.mjs
@@ -7,7 +7,9 @@ const root = resolve(here, "../../..");
 
 const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
 const template = readFileSync(resolve(here, "../src/manifest.json"), "utf8");
-const version = (process.env.VERSION ?? "0.0.0-dev").replace(/^v/, "");
+// Chrome requires version to be 1-4 dot-separated integers, so the
+// local-dev fallback must not contain a suffix like "-dev".
+const version = (process.env.VERSION ?? "0.0.0").replace(/^v/, "");
 
 const out = ejs.render(template, { ...pkg, version });
 const outPath = resolve(root, "out/manifest.json");


### PR DESCRIPTION
## Problem

A sync batch snapshots avatar URLs at `prepareBatch` time, but the batch can take a long time to finish (service worker kills + 1-minute continue alarms). A user who sets a custom avatar after the batch was prepared but before their turn comes up gets registered with the stale default-avatar placeholder, even though their profile already has a real photo.

This was observed in the wild: an emoji was registered with the bundled placeholder while the user's `avatar_hash` was already a custom hex hash at registration time — the batch had been prepared before the avatar was set.

## Fix

- Add `userId` to `UserEmoji`
- Extract the avatar URL selection (including the `g`-prefixed `avatar_hash` → placeholder detection) into an `avatarUrl()` helper
- Add `refreshAvatarUrls(batch)`: re-fetch `users.list` and swap in fresh URLs keyed by user ID
- Call it on the resume path in `main.ts` before processing continues

## Design notes

- **No index shift**: only `url` is replaced; `userEmojis` order and `processedIndex` are untouched, so renames or departures during a batch can't desync resume progress
- **Departed users**: missing from the fresh list → keep the original URL
- **Backward compatible**: batches persisted before this change have no `userId`, so lookup misses and the original URL is used
- **Cost**: one paginated `users.list` fetch per resume; no per-user `users.info` calls

## Testing

- `vitest run`: background 1 passed, shared 12 passed
- `tsc` / Prettier: pass for the touched package

🤖 Generated with [Claude Code](https://claude.com/claude-code)