### PR TITLE
Update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.12.0"
       - name: Use pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@v6
         with:
           version: "9.14.4"
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
       - name: Zip
         run: zip -r uemoji.zip out
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: uemoji-zip
           path: uemoji.zip
@@ -43,7 +43,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: uemoji-zip
       - name: Upload to GitHub release
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: uemoji-zip
       - name: Upload to Chrome Web Store

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.12.0"
       - name: Use pnpm
-        uses: pnpm/action-setup@v4.0.0
+        uses: pnpm/action-setup@v6
         with:
           version: "9.14.4"
       - name: Install dependencies


### PR DESCRIPTION
## Why

The v0.0.12 release run warned that Node.js 20 actions are deprecated: GitHub Actions runners will force Node 24 from **2026-06-16** and remove Node 20 on **2026-09-16**.

## Changes

Bump all actions in `release.yml` / `test.yml` to their latest majors (all Node 24 compatible):

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `pnpm/action-setup` v4.0.0 → v6

Workflow inputs are unchanged across these majors for the options used here (artifact name/path, node-version, pnpm version).

## Verification

- Test workflow runs on push to this branch
- Release workflow can only be verified on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)